### PR TITLE
[EZ] Replace `pytorch-labs` with `meta-pytorch`

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,9 +33,9 @@ For more details about Mixtral 8x7B, please check [this page](./mixtral-moe) or 
 
 ## Examples
 In the spirit of keeping the repo minimal, here are various examples of extensions you can make to gpt-fast as PRs.
-- [Google Gemma](https://github.com/pytorch-labs/gpt-fast/pull/115)
-- [xAI Grok-1](https://github.com/pytorch-labs/gpt-fast/pull/171)
-- [Databricks DBRX](https://github.com/pytorch-labs/gpt-fast/pull/174)
+- [Google Gemma](https://github.com/meta-pytorch/gpt-fast/pull/115)
+- [xAI Grok-1](https://github.com/meta-pytorch/gpt-fast/pull/171)
+- [Databricks DBRX](https://github.com/meta-pytorch/gpt-fast/pull/174)
 
 ## Community
 
@@ -221,7 +221,7 @@ You can then eval or generate text with this model in the same way as above.
 
 ## License
 
-`gpt-fast` is released under the [BSD 3](https://github.com/pytorch-labs/gpt-fast/main/LICENSE) license.
+`gpt-fast` is released under the [BSD 3](https://github.com/meta-pytorch/gpt-fast/main/LICENSE) license.
 
 ## Acknowledgements
 Thanks to:

--- a/setup.py
+++ b/setup.py
@@ -15,5 +15,5 @@ setup(
     description='A simple, fast, pure PyTorch Llama inference engine',
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',
-    url='https://github.com/pytorch-labs/gpt-fast',
+    url='https://github.com/meta-pytorch/gpt-fast',
 )


### PR DESCRIPTION
This PR replaces all instances of `pytorch-labs` with `meta-pytorch` in this repository now that the `pytorch-labs` org has been renamed to `meta-pytorch`

## Changes Made
- Replaced all occurrences of `pytorch-labs` with `meta-pytorch`
- Skipped binary files and files larger than 1MB due to GitHub api payload limits in the script to cover all repos in this org. Will do a more manual second pass later to cover any larger files

## Files Modified
This PR updates files that contained the target text.

Generated by automated script on 2025-08-22T23:25:56.378456+00:00Z